### PR TITLE
Fix/buffer size

### DIFF
--- a/internal/term/handler_dashboard.go
+++ b/internal/term/handler_dashboard.go
@@ -214,8 +214,8 @@ func (t *Term) Run() {
 	tickerCount++
 	uiEvents := ui.PollEvents()
 
-	ticker := time.NewTicker(time.Second * 10).C
-	tickerParagraphe := time.NewTicker(time.Second).C
+	tickerUI := time.NewTicker(time.Second * 10).C
+	tickerParser := time.NewTicker(time.Second).C
 
 	for {
 		select {
@@ -224,9 +224,9 @@ func (t *Term) Run() {
 			case "q", "<C-c>":
 				return
 			}
-		case <-ticker:
+		case <-tickerUI:
 			drawDashboard(initalStat, t, dashboard, &max)
-		case <-tickerParagraphe:
+		case <-tickerParser:
 			updateParagraph(tickerCount)
 			t.Parse(initalStat)
 			tickerCount++

--- a/internal/term/handler_dashboard.go
+++ b/internal/term/handler_dashboard.go
@@ -150,7 +150,7 @@ func drawLine(d *dashboard, t *Term) {
 
 // every 10 seconds draw the dashboard
 func drawDashboard(initalStat os.FileInfo, t *Term, d *dashboard, max *int) {
-	t.Parse(initalStat)
+	//	t.Parse(initalStat)
 	// looking for the max len of queue
 	// if max is upper than threshold, trigger an alert
 	if len(t.queue) > *max {
@@ -188,7 +188,7 @@ func (t *Term) Run() {
 	}
 	defer ui.Close()
 
-	initalStat, err := os.Stat("localfile.log")
+	initalStat, err := os.Stat(t.logfile)
 	if err != nil {
 		panic(err)
 	}
@@ -228,6 +228,7 @@ func (t *Term) Run() {
 			drawDashboard(initalStat, t, dashboard, &max)
 		case <-tickerParagraphe:
 			updateParagraph(tickerCount)
+			t.Parse(initalStat)
 			tickerCount++
 		}
 	}

--- a/internal/term/handler_logfile.go
+++ b/internal/term/handler_logfile.go
@@ -5,6 +5,9 @@ import (
 	"regexp"
 )
 
+var reDate = regexp.MustCompile(`(?m)\[(.+)\]`)
+var reSec = regexp.MustCompile(`\s/([a-z]+)`)
+
 // Parse logfile file to get new line added
 func (t *Term) Parse(initialState os.FileInfo) {
 	file, err := os.Open(t.logfile)
@@ -21,9 +24,10 @@ func (t *Term) Parse(initialState os.FileInfo) {
 	// use the file size before a trafic in log file it's observed
 	// and substract it to current file size to get a len and cap value of new lines added
 	buf := make([]byte,
-		t.previousState.Size()+(t.previousState.Size()-initialState.Size()),
-		t.previousState.Size()+(t.previousState.Size()-initialState.Size()),
+		initialState.Size()-t.previousState.Size(),
+		initialState.Size()-t.previousState.Size(),
 	)
+
 	// if the init size and the current size are different and the update date are different
 	if t.previousState.Size() != initialState.Size() && t.previousState.ModTime() != initialState.ModTime() {
 		start := t.previousState.Size()
@@ -36,9 +40,6 @@ func (t *Term) Parse(initialState os.FileInfo) {
 
 // get all section found in new lines added
 func (t *Term) parseLine(b []byte) {
-	reDate := regexp.MustCompile(`(?m)\[(.+)\]`)
-	reSec := regexp.MustCompile(`\s/([a-z]+)`)
-
 	sections := reSec.FindAllString(string(b), -1)
 	dates := reDate.FindAllString(string(b), -1)
 


### PR DESCRIPTION
Get an error after adding a plenty of data in logfile.

After troubleshooting, detect a inconsistency between initial file state and previous file state

Otherwise, improve efficiency by parsing logfile every second instead of every 10 seconds